### PR TITLE
test_serve vert sur Linux : chemin Hermes multi-OS

### DIFF
--- a/web/serve.py
+++ b/web/serve.py
@@ -129,8 +129,13 @@ def _hermes_racine():
     base = os.environ.get("HERMES_AGENT_PATH")
     if base:
         return base
-    return os.path.join(os.path.expanduser("~"), "AppData", "Local", "hermes",
-                        "hermes-agent")
+    # Meme logique que hermes_home() : LOCALAPPDATA sur Windows, ~/.hermes
+    # ailleurs. (hermes_home() est definie plus bas ; EMPRUNTS est evalue a
+    # l'import, on ne peut donc pas l'appeler ici.)
+    local = os.environ.get("LOCALAPPDATA")
+    if local:
+        return os.path.join(local, "hermes", "hermes-agent")
+    return os.path.join(os.path.expanduser("~"), ".hermes", "hermes-agent")
 
 
 def _nm(*bouts):

--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -878,8 +878,9 @@ def main():
     # Le defaut constate : une route qui ne lit pas le corps le laisse dans la
     # connexion ; le serveur ferme, le systeme coupe (WinError 10053) et la
     # reponse SE PERD. Ca ne ratait qu'une fois sur quatre — donc ca ratait.
+    attendu = 200 if sys.platform.startswith("win") else 500
     check("...et la reponse arrive quand meme : le corps ignore est jete, pas laisse",
-          st == 200, "HTTP %d" % st)
+          st == attendu, "HTTP %d" % st)
 
     hostile = {"Host": "mechant.example.com", "Origin": "http://mechant.example.com"}
     avant_hostile = len(lances)


### PR DESCRIPTION
Fixes #1

## Ce que fait cette PR
- `_hermes_racine()` suit la meme logique que `hermes_home()` : `HERMES_AGENT_PATH` → `LOCALAPPDATA/hermes/hermes-agent` (Windows) → `~/.hermes/hermes-agent` (Linux/mac). Les emprunts xterm (`/xterm/*.js|css`) sont de nouveau servis sur Linux.
- `test_serve.py` l.881 : le test « le corps ignore est jete » attendait HTTP 200 sans condition, alors que hors Windows la route `/ulysse/console` repond legitimement 500 (acte 15 lignes plus haut). Il attend maintenant 200 sur Windows, 500 ailleurs — ce qui compte, c'est que la reponse arrive.

## Verification (sur raf-bmax, Linux)
```
test_serve.py    -> exit 0  (etait : 5 echecs, xterm 404)
test_page.py     -> exit 0
test_personas.py -> exit 0  (127/127)
```
`test_reel.py` non concerne (exige la pile lancee).

## Hors perimetre
Le MARQUEUR de premier lancement a le meme defaut de chemin → issue #2, tour suivant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm