### PR TITLE
CI : gh pr checks verifie enfin quelque chose

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+# CI de la boucle de peaufinage : donne un sens a `gh pr checks` (Phase C).
+#
+# Seules tournent ici les suites sans dependance locale vivante :
+#   - test_serve.py    (les faux backends sont dans le test lui-meme)
+#   - test_personas.py (autonome)
+# Restent locales : test_page.py (proxy Hermes + modeles LLM externes) et
+# test_reel.py (exige la pile lancee).
+name: tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # test_serve emprunte xterm a l'installation Hermes. Le runner n'a pas
+      # de Hermes : on installe la vraie bibliotheque dans un dossier neutre,
+      # que serve.py sait designer via HERMES_AGENT_PATH.
+      - name: Fournir les emprunts xterm
+        run: npm install --prefix "$RUNNER_TEMP/hermes-agent" @xterm/xterm @xterm/addon-fit
+
+      - name: test_serve
+        working-directory: web
+        env:
+          HERMES_AGENT_PATH: ${{ runner.temp }}/hermes-agent
+        run: python3 test_serve.py
+
+      - name: test_personas
+        working-directory: web
+        run: python3 test_personas.py


### PR DESCRIPTION
Fixes #5

## Ce que fait cette PR
Ajoute `.github/workflows/tests.yml` : sur chaque PR et chaque push master, un job **tests** lance `test_serve.py` et `test_personas.py` sur ubuntu-latest (Python 3.12).

- Les emprunts xterm de `test_serve` sont fournis par un vrai `npm install @xterm/xterm @xterm/addon-fit` dans un dossier neutre designe par `HERMES_AGENT_PATH` — mecanisme deja prevu par `serve.py`, valide localement (exit 0).
- `test_page.py` (proxy Hermes + modeles LLM vivants) et `test_reel.py` (pile lancee) restent des verifications locales : sur un runner ils planteraient pour cause d'environnement, pas de code.

Cette PR sert aussi de premier cobaye : le check « tests » doit apparaitre et passer au vert ici meme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm