### PR TITLE
serve.py ecoute le port resolu par verif_ports

### DIFF
--- a/web/lancer_ulysse.bat
+++ b/web/lancer_ulysse.bat
@@ -62,7 +62,7 @@ timeout /t 5 >nul
 
 REM --- 4. Serveur Ulysse (statique + proxy authentifie) --------------------
 echo Demarrage du serveur Ulysse sur le port %ULYSSE_PORT%...
-start "Ulysse-Serve" /MIN cmd /c "python serve.py"
+start "Ulysse-Serve" /MIN cmd /c "python serve.py --port %ULYSSE_PORT%"
 
 timeout /t 2 >nul
 

--- a/web/serve.py
+++ b/web/serve.py
@@ -1782,8 +1782,31 @@ def port_deja_pris(host, port, delai=0.4):
         return False
 
 
+def port_effectif(argv, env):
+    """Le port d'ecoute reel : --port N (argv) prime, sinon ULYSSE_PORT (env),
+    sinon la constante PORT du fichier.
+
+    C'est le contrat de verif_ports.py : quand 8080 est pris, il resout un
+    port libre et le transmet via ulysse_ports.bat — un serveur qui l'ignore
+    rend la bascule inutile (le navigateur s'ouvre sur un port ou personne
+    n'ecoute)."""
+    if "--port" in argv:
+        try:
+            return int(argv[argv.index("--port") + 1])
+        except (IndexError, ValueError):
+            raise SystemExit("Usage : python serve.py [--port N]")
+    brut = env.get("ULYSSE_PORT", "")
+    if brut:
+        try:
+            return int(brut)
+        except ValueError:
+            raise SystemExit("ULYSSE_PORT doit etre un entier, pas %r" % brut)
+    return PORT
+
+
 def main():
-    global BACKEND, WEBHOOK_BACKEND, PROXY_BACKEND, ALLOWED_HOSTS, ALLOWED_ORIGINS
+    global BACKEND, WEBHOOK_BACKEND, PROXY_BACKEND, ALLOWED_HOSTS, ALLOWED_ORIGINS, PORT
+    PORT = port_effectif(sys.argv[1:], os.environ)
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
     url, token, wh_url, proxy_url, proxy_token = load_config()

--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -1081,6 +1081,26 @@ def main():
     else:
         print("  (plugin non installe sur cette machine — comparaison non faite)")
 
+    print("\n=== 7. Le port suit verif_ports (issue #7) ===")
+
+    # Le contrat : verif_ports.py resout un port libre et le transmet ;
+    # serve.py doit l'ecouter, pas retomber sur 8080 en dur.
+    check("--port en argv prime sur tout",
+          serve.port_effectif(["--port", "8123"], {"ULYSSE_PORT": "8999"}) == 8123)
+    check("ULYSSE_PORT en env est lu quand argv n'en dit rien",
+          serve.port_effectif([], {"ULYSSE_PORT": "8124"}) == 8124)
+    check("sans argv ni env, la constante PORT du fichier reste le defaut",
+          serve.port_effectif([], {}) == serve.PORT)
+    for mauvais_argv, mauvais_env in ((["--port"], {}), (["--port", "abc"], {}),
+                                      ([], {"ULYSSE_PORT": "abc"})):
+        try:
+            serve.port_effectif(mauvais_argv, mauvais_env)
+            refuse = False
+        except SystemExit:
+            refuse = True
+        check("une valeur invalide est refusee net : argv=%r env=%r"
+              % (mauvais_argv, mauvais_env), refuse)
+
     # --- bilan ---------------------------------------------------------
     passed = sum(1 for _, ok, _ in results if ok)
     total = len(results)


### PR DESCRIPTION
Fixes #7

## Ce que fait cette PR
- `port_effectif(argv, env)` dans serve.py : `--port N` prime, sinon `ULYSSE_PORT`, sinon la constante `PORT` (defaut 8080 inchange). Valeur invalide → refus net avec message.
- `main()` resout le port en premiere ligne : `ALLOWED_HOSTS`/`ALLOWED_ORIGINS`, `port_deja_pris`, la banniere et le bind suivent tous le port effectif.
- `lancer_ulysse.bat` : `python serve.py --port %ULYSSE_PORT%` — le port resolu est enfin transmis, comme pour le dashboard.
- 6 nouveaux cas dans test_serve.py (section 7) : priorite argv > env > constante, et refus des valeurs invalides.

## Verification (raf-bmax, Linux)
```
test_serve.py    -> exit 0 (117/117, dont les 6 nouveaux)
test_page.py     -> exit 0
test_personas.py -> exit 0
ULYSSE_PORT=18099 -> port_effectif rend 18099
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm