### PR TITLE
Un test fige l'egalite serve.PORT == verif_ports.UI_PORT

### DIFF
--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -1091,6 +1091,17 @@ def main():
           serve.port_effectif([], {"ULYSSE_PORT": "8124"}) == 8124)
     check("sans argv ni env, la constante PORT du fichier reste le defaut",
           serve.port_effectif([], {}) == serve.PORT)
+    # Les deux moities du lancement partent du MEME port par defaut : si l'une
+    # bouge sans l'autre, verif_ports resout un port ou serve n'ecoute pas et
+    # le navigateur s'ouvre sur du vide (issue #11 — constate sur une machine
+    # ou serve.py avait ete edite a 8090 en local, verif_ports restant a 8080).
+    import verif_ports
+    check("serve.PORT et verif_ports.UI_PORT partent du meme defaut",
+          serve.PORT == verif_ports.UI_PORT,
+          "serve=%d verif_ports=%d" % (serve.PORT, verif_ports.UI_PORT))
+    check("le dashboard demarre la ou la config l'attend (9123)",
+          verif_ports.DASH_ULYSSE_PORT == 9123,
+          str(verif_ports.DASH_ULYSSE_PORT))
     for mauvais_argv, mauvais_env in ((["--port"], {}), (["--port", "abc"], {}),
                                       ([], {"ULYSSE_PORT": "abc"})):
         try:

--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -1095,10 +1095,15 @@ def main():
     # bouge sans l'autre, verif_ports resout un port ou serve n'ecoute pas et
     # le navigateur s'ouvre sur du vide (issue #11 — constate sur une machine
     # ou serve.py avait ete edite a 8090 en local, verif_ports restant a 8080).
+    # `serve.PORT` ne se lit pas ici : ce banc l'a mute a 18080 pour son
+    # propre serveur. La constante du FICHIER, elle, ne ment pas.
     import verif_ports
+    with open("serve.py", encoding="utf-8") as f:
+        m = re.search(r"^PORT = (\d+)", f.read(), re.M)
+    defaut_serve = int(m.group(1)) if m else -1
     check("serve.PORT et verif_ports.UI_PORT partent du meme defaut",
-          serve.PORT == verif_ports.UI_PORT,
-          "serve=%d verif_ports=%d" % (serve.PORT, verif_ports.UI_PORT))
+          defaut_serve == verif_ports.UI_PORT,
+          "serve=%d verif_ports=%d" % (defaut_serve, verif_ports.UI_PORT))
     check("le dashboard demarre la ou la config l'attend (9123)",
           verif_ports.DASH_ULYSSE_PORT == 9123,
           str(verif_ports.DASH_ULYSSE_PORT))


### PR DESCRIPTION
Fixes #11

## Contexte
La premisse de l'issue est rectifiee en commentaire : sur master, `PORT = 8080` — le 8090 observe etait une modification locale non commitee sur raf-bmax. Mais la divergence a ete reelle sur cette machine, et le garde-fou demande la rend impossible en silence.

## Ce que fait cette PR
Deux checks de plus en section 7 de `test_serve.py` : `serve.PORT == verif_ports.UI_PORT` et `verif_ports.DASH_ULYSSE_PORT == 9123`.

## Verification
`test_serve.py` -> exit 0 (119 verifications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm