### PR TITLE
sign_webhook.py parle enfin V2 au gateway

### DIFF
--- a/_outils/sign_webhook.py
+++ b/_outils/sign_webhook.py
@@ -1,12 +1,28 @@
-import hmac, hashlib, json, urllib.request, sys
+"""Essai manuel d'un webhook : signe le corps en V2, comme le gateway l'exige.
 
-secret = "ulysse-test-secret"
-url = "http://127.0.0.1:8644/webhooks/resume-lundi"
+Le gateway (gateway/platforms/webhook.py) calcule HMAC-SHA256(secret,
+b"<timestamp>.<body>") et lit X-Webhook-Signature-V2 + X-Webhook-Timestamp
+(rejeu refuse au-dela de 300 s). L'ancien en-tete X-Signature (V1 morte) ne
+matche aucune branche : 401 garanti — c'est ce que cet outil envoyait.
+
+    python3 sign_webhook.py [url] [secret]
+"""
+import hashlib, hmac, json, sys, time, urllib.request, urllib.error
+
+url = sys.argv[1] if len(sys.argv) > 1 else "http://127.0.0.1:8644/webhooks/resume-lundi"
+secret = sys.argv[2] if len(sys.argv) > 2 else "ulysse-test-secret"
 body = json.dumps({"sujet": "intelligence artificielle", "user": "Sophie"}).encode()
-sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json", "X-Signature": sig}, method="POST")
+ts = str(int(time.time()))
+sig = hmac.new(secret.encode(), ts.encode("ascii") + b"." + body, hashlib.sha256).hexdigest()
+req = urllib.request.Request(url, data=body, headers={
+    "Content-Type": "application/json",
+    "X-Webhook-Timestamp": ts,
+    "X-Webhook-Signature-V2": sig,
+}, method="POST")
 try:
     r = urllib.request.urlopen(req, timeout=10)
     print("POST webhook HTTP", r.status)
+    sys.exit(0 if r.status == 200 else 1)
 except urllib.error.HTTPError as e:
     print("POST webhook HTTP", e.code, e.read()[:200])
+    sys.exit(1)


### PR DESCRIPTION
Fixes #15

## Ce que fait cette PR
`_outils/sign_webhook.py` signait `X-Signature: sha256=<hmac du corps>` — un dialecte que le gateway ne lit pas (il attend `X-Webhook-Signature-V2` + `X-Webhook-Timestamp`, HMAC sur `<ts>.<body>`, rejeu 300 s). L'outil signe desormais exactement comme `serve.py:sign_webhook_v2`, accepte `[url] [secret]` en arguments pour viser un gateway d'essai, et sort en 0/1 selon la reponse.

## Verification (raf-bmax, Linux)
Contre une replique exacte de la branche V2 du gateway (webhook.py:1086-1111, la meme que le FakeGateway de test_serve.py) sur port ephemere :
```
bon secret     -> POST webhook HTTP 200, exit 0
mauvais secret -> POST webhook HTTP 401, exit 1
```
Les 4 suites statiques restent vertes (test_serve, test_personas, test_verif_ports, test_page.js).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm