### PR TITLE
GET /ulysse-config.js : le 404 du fichier manquant entre au banc

### DIFF
--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -597,6 +597,21 @@ def main():
           'SESSION_TOKEN: ""' in txt or 'SESSION_TOKEN:""' in txt
           or "SESSION_TOKEN" not in txt, txt[:0])
 
+    # Le fichier peut MANQUER (config perdue, deplacee) : la route doit le
+    # dire par un 404 net, pas servir un corps vide qui casserait la page
+    # en silence (issue #23). La route lit CONFIG_FILE a la requete : on le
+    # pointe vers un nom qui n'existe pas, puis on le remet.
+    config_avant = serve.CONFIG_FILE
+    serve.CONFIG_FILE = "config-envolee-essai.js"
+    try:
+        st, _, _ = req("GET", "/" + serve.CONFIG_FILE, headers=same)
+    finally:
+        serve.CONFIG_FILE = config_avant
+    check("Config introuvable -> 404, pas un 200 vide", st == 404, "HTTP %d" % st)
+    st, _, txt = req("GET", "/" + serve.CONFIG_FILE, headers=same)
+    check("...et le nominal marche toujours apres la remise en place",
+          st == 200 and "PREMIER = true" in txt, "HTTP %d" % st)
+
     # Le fichier SERVI n'est pas le fichier sur DISQUE : serve.py y ajoute une
     # ligne. Les tests de page lisent le disque et ne verraient donc jamais
     # une erreur dans cette ligne — c'est exactement ce qui est arrive :


### PR DESCRIPTION
Fixes #23

Deux checks apres le nominal existant : `CONFIG_FILE` pointe vers un nom inexistant (la route le lit a la requete) -> **404** ; remise en place -> le nominal (200 + marqueur `PREMIER`) repond toujours.

Verification : test_serve.py -> 143/143, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm