### PR TITLE
corbeille/vider : le 400 du corps sans champ utile entre au banc

### DIFF
--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -1340,6 +1340,14 @@ def main():
     check("vider avec un identifiant-chemin est refuse sans rien effacer",
           st == 409 and os.path.isfile(os.path.join(corbeille, e2.get("id", "?"))),
           "HTTP %d" % st)
+    # Un JSON valide mais sans champ utile ne detruit RIEN : ni « id », ni
+    # « tout: true » -> on refuse, on n'interprete pas (issue #36).
+    st, _, _ = vider({})
+    check("vider sans « id » ni « tout » -> 400", st == 400, "HTTP %d" % st)
+    st, _, _ = vider({"id": 123})
+    check("...et un « id » non-texte -> 400", st == 400, "HTTP %d" % st)
+    check("...sans qu'aucun de ces refus n'ait rien efface",
+          os.path.isfile(os.path.join(corbeille, e2.get("id", "?"))))
     st, _, corps = vider({"id": e2.get("id", "?")})
     check("vider un element : 200, efface=1, et il n'est plus la",
           st == 200 and json.loads(corps).get("efface") == 1


### PR DESCRIPTION
Fixes #36

Deux refus, JSON valide mais vide de sens : `{}` -> **400** ; `{\"id\": 123}` -> **400** — et la preuve qu'aucun element de la corbeille n'est parti au passage.

Verification : test_serve.py -> 169/169, exit 0 (la branche part du master courant ; #38, dans une autre region du fichier, ajoutera ses 4 checks au merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm