### PR TITLE
vider : l'orphelin est purge de l'index sans etre compte

### DIFF
--- a/web/serve.py
+++ b/web/serve.py
@@ -587,6 +587,11 @@ def corbeille_vider(ident=None):
                 shutil.rmtree(cible)
             elif os.path.exists(cible) or os.path.islink(cible):
                 os.remove(cible)
+            else:
+                # Sorti a la main : rien a effacer ICI. L'index est purge
+                # plus bas, mais « efface » ne compte que ce que NOTRE geste
+                # a fait disparaitre — un compteur qui compte l'absent ment.
+                continue
             efface += 1
         except OSError:
             continue          # on garde l'entree : elle est encore la

--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -1411,11 +1411,16 @@ def main():
           st == 200 and e3.get("id") not in vus, str(vus))
 
     # -- vider tout : l'index connu part, la corbeille finit vide ----------
+    # A ce stade l'index ne porte QUE l'entree orpheline (sortie a la main) :
+    # vider doit purger l'index sans la compter — « efface » ne dit que ce
+    # que le geste a reellement fait disparaitre (issue #41).
     st, _, corps = vider({"tout": True})
     st2, _, corps2 = req("GET", "/ulysse/corbeille", headers=same)
     check("vider tout -> 200, et la liste finit vide",
           st == 200 and st2 == 200 and json.loads(corps2).get("entrees") == [],
           "HTTP %d puis %s" % (st, corps2[:60]))
+    check("...et l'orphelin purge de l'index n'est PAS compte comme efface",
+          st == 200 and json.loads(corps).get("efface") == 0, corps[:60])
 
     print("\n=== 9. /ulysse/set-model : la route, pas seulement son helper (issue #20) ===")
 


### PR DESCRIPTION
Fixes #41

L'issue demandait un test ; le test a revele que le code disait faux : une entree dont le fichier etait deja sorti a la main **incrementait `efface`** alors que rien n'avait ete efface par la route. Correctif minimal (une branche `else: continue` dans `corbeille_vider`) : l'index est toujours purge (comportement inchange), mais `efface` ne compte que ce que le geste a reellement fait disparaitre. Le banc fige les deux : liste vide apres `tout:true`, et `efface == 0` pour l'orphelin.

Verification : test_serve.py -> 174/174, exit 0 ; les 3 autres suites vertes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm