### PR TITLE
Revert : la config locale (port 8090, tailnet) ressort du depot

### DIFF
--- a/web/serve.py
+++ b/web/serve.py
@@ -62,7 +62,7 @@ import urllib.parse
 # EDITER ICI — configuration du serveur
 # ===========================================================================
 
-PORT = 8090
+PORT = 8080
 
 # Interface d'ecoute. 127.0.0.1 = accessible depuis CETTE machine uniquement.
 # Ne PAS mettre "" ni "0.0.0.0" : le proxy porte le jeton du dashboard, donc
@@ -1836,13 +1836,10 @@ def main():
     # soit une erreur de configuration, soit une tentative de rebinding.
     ALLOWED_HOSTS = frozenset({
         "127.0.0.1:%d" % PORT, "localhost:%d" % PORT, "[::1]:%d" % PORT,
-        # Acces tailnet (telephone de Raf) — expose via `tailscale serve`.
-        "raf-bmax.tail14baaa.ts.net:%d" % PORT,
     })
     ALLOWED_ORIGINS = frozenset({
         "http://127.0.0.1:%d" % PORT, "http://localhost:%d" % PORT,
         "http://[::1]:%d" % PORT,
-        "https://raf-bmax.tail14baaa.ts.net:%d" % PORT,
     })
 
     # AVANT toute banniere : si quelqu'un repond deja ici, se lier par-dessus

--- a/web/ulysse-config.js
+++ b/web/ulysse-config.js
@@ -34,7 +34,7 @@ window.ULYSSE_CONFIG = {
   /* --- Lu par serve.py uniquement ---------------------------------------- */
 
   // Origine reelle du dashboard Hermes. Pas de slash final.
-  HERMES_URL: "http://127.0.0.1:9119",
+  HERMES_URL: "http://127.0.0.1:9123",
 
   // Gateway des webhooks. serve.py y relaie POST /webhooks/<nom> en posant
   // lui-meme la signature HMAC (le secret est lu dans le Hermes Home).


### PR DESCRIPTION
**Urgent pour la Phase C — a merger en priorite.**

Le commit f3c423d (pousse directement sur master, hors protocole) a fait entrer dans le depot la config locale de la machine de Raf : `PORT = 8090`, les hotes **tailnet** et le dashboard 9119. Trois problemes :

1. **Le depot est PUBLIC** : un nom d'hote tailnet n'a rien a faire dans un depot public.
2. **La CI de master est ROUGE depuis ce commit** : le garde d'egalite `serve.PORT == verif_ports.UI_PORT` (#11) le detecte — c'est exactement le scenario pour lequel il a ete construit. (Et #42/#43 ont ete merges par-dessus malgre le rouge : en Phase C, checks rouges = on commente, on ne merge pas.)
3. La config machine-specifique redevient ce qu'elle etait : des **modifications locales non commitees** (patch sauvegarde chez Raf : `~/config-locale-bmax.patch`).

Ce revert retire la config (BRIEF.md est conserve). Apres merge, la CI de master repasse au vert.

**Rappel de protocole (2e ecart)** : personne ne committe sur master — ni push, ni commit local, meme pour de la config. Branche + PR, toujours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm