### PR TITLE
PUT/PATCH/DELETE hostiles -> 403 avant relais, banc a l'appui

### DIFF
--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -1404,6 +1404,16 @@ def main():
               and FakeDashboard.seen[-1].get("method") == methode,
               "HTTP %d — vu: %s" % (st, FakeDashboard.seen[-1].get("method")
                                     if FakeDashboard.seen else "rien"))
+        # La garde tient AUSSI sur ces methodes : Host ou Origin etrangere ->
+        # 403 avant le relais, rien n'atteint le dashboard (issue #66).
+        FakeDashboard.seen.clear()
+        st1, _, _ = req(methode, "/api/foo",
+                        headers=dict(same, Host="mechant.example.com"))
+        st2, _, _ = req(methode, "/api/foo",
+                        headers={"Origin": "http://evil.example.com"})
+        check("%s hostile (Host puis Origin) -> 403, rien ne passe" % methode,
+              st1 == 403 and st2 == 403 and not FakeDashboard.seen,
+              "HTTP %d / %d — vus: %d" % (st1, st2, len(FakeDashboard.seen)))
 
     print("\n=== 7. Le port suit verif_ports (issue #7) ===")
 


### PR DESCRIPTION
Fixes #66

Pour chacune des trois methodes sur `/api/foo` : **Host etranger -> 403** puis **Origin etrangere -> 403**, et `FakeDashboard.seen` reste vide — rien n'atteint le dashboard, la garde refuse avant le relais.

Verification : test_serve.py -> 203/203, stable sur 2 runs. (Peut arriver en conflit trivial avec #67 si merges croises : les deux ajoutent des checks dans des blocs distincts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm