### PR TITLE
set-model : le 500 de l'ecriture impossible entre au banc

### DIFF
--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -1874,6 +1874,28 @@ def main():
               "HTTP %d" % st)
         os.remove(coffre)
 
+        # L'ECRITURE elle-meme peut echouer (fichier verrouille) : la garde a
+        # ete posee, mais la valeur ne rentre pas — 500 « Ecriture impossible »
+        # et le fichier n'a pas change d'un octet (issue #77).
+        with open(copie, "rb") as f:
+            octets_verrou = f.read()
+        os.chmod(copie, 0o444)
+        try:
+            st, _, txt = set_model({"key": "PROXY_MODEL", "value": "verrouille"})
+        finally:
+            os.chmod(copie, 0o644)
+        with open(copie, "rb") as f:
+            apres_verrou = f.read()
+        check("fichier config verrouille -> 500 « Ecriture impossible », intact",
+              st == 500 and "impossible" in txt and apres_verrou == octets_verrou,
+              "HTTP %d — %s" % (st, txt[:80]))
+        st, _, _ = set_model({"key": "PROXY_MODEL", "value": "deverrouille"})
+        with open(copie, encoding="utf-8", newline="") as f:
+            texte = f.read()
+        check("...et deverrouille, la meme ecriture passe (200)",
+              st == 200 and 'PROXY_MODEL: "deverrouille"' in texte,
+              "HTTP %d" % st)
+
         serve.CONFIG_FILE = os.path.join(etabli, "n-existe-pas.js")
         st, _, _ = set_model({"key": "PROXY_MODEL", "value": "x"})
         check("config introuvable -> 404", st == 404, "HTTP %d" % st)


### PR DESCRIPTION
Fixes #77

Copie jetable en **lecture seule** (chmod remis en `finally`) : `set-model` -> **500 « Ecriture impossible »**, fichier intact octet pour octet ; deverrouille, la meme ecriture passe (200, valeur en place).

Verification : test_serve.py -> 213/213, stable sur 2 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm