### PR TITLE
WS : le refus non-101 de l'amont traverse tel quel

### DIFF
--- a/web/test_serve.py
+++ b/web/test_serve.py
@@ -539,6 +539,21 @@ def main():
     check("E1 ...et le 101 repasse quand le dashboard revient", st == 101,
           head.splitlines()[0] if head else "")
 
+    # Le dashboard VIT mais refuse le handshake (jeton rejete par l'amont) :
+    # son statut de refus traverse tel quel, aucun tunnel ne s'ouvre, et le
+    # nominal repasse juste apres (issue #86).
+    backend_jeton = serve.BACKEND
+    serve.BACKEND = serve.Backend(backend_jeton.url, "jeton-que-l-amont-rejette")
+    try:
+        st, head, payload = ws_handshake(same)
+    finally:
+        serve.BACKEND = backend_jeton
+    check("E1 refus amont au handshake -> son statut traverse (401), pas d'invente",
+          st == 401, "HTTP %d" % st)
+    st, head, payload = ws_handshake(same)
+    check("E1 ...et le 101 nominal repasse, rien n'est casse", st == 101,
+          head.splitlines()[0] if head else "")
+
     print("\n=== 3. Jeton : injecte, jamais divulgue (S6-S9) ===")
     FakeDashboard.seen.clear()
     req("GET", "/api/status", headers=same)


### PR DESCRIPTION
Fixes #86

`serve.BACKEND` porte un jeton que le faux dashboard rejette au handshake : le **401 de l'amont traverse tel quel** (pas de statut invente, pas de tunnel qui pend), remise en place en `finally`, et le **101 nominal repasse** juste apres.

Verification : test_serve.py -> 221/221, stable sur 2 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm