### PR TITLE
Corbeille : le bouton de vidage dit sa portee reelle

### DIFF
--- a/web/ulysse-app.js
+++ b/web/ulysse-app.js
@@ -1221,9 +1221,15 @@ async function binDessine(){
      lettres : c'est la dernière chose qu'on lit avant qu'il n'y ait plus de
      retour. Le chemin reste affiché — on peut toujours aller voir soi-même
      plutôt que de nous croire sur parole. */
+  /* Le bouton dit sa PORTÉE : il ne vide que les fichiers (l'index de la
+     corbeille), jamais les projets archivés — ceux-ci partent un par un,
+     par leur propre bouton, vers `projects.delete`. Quand des projets sont
+     affichés à côté, « Vider la corbeille » mentirait : le panneau
+     annoncerait 5 et le bouton n'en effacerait que 3. */
+  const viderQuoi = projets.length ? "Vider les fichiers" : "Vider la corbeille";
   const pied = '<div class="bin-pied">'
     + (items.length
-        ? '<button class="dangerlink" id="binVider">Vider la corbeille — '
+        ? '<button class="dangerlink" id="binVider">' + viderQuoi + " — "
           + items.length + " élément" + (items.length > 1 ? "s" : "")
           + ", définitivement</button>"
         : "")
@@ -1296,7 +1302,7 @@ async function binDessine(){
   const vider = $("binVider");
   if (vider) vider.onclick = (ev) => {
     ev.stopPropagation();
-    binConfirmer("Vider la corbeille ?",
+    binConfirmer(viderQuoi + " ?",
       items.length + " élément" + (items.length > 1 ? "s partent" : " part")
       + " du disque pour de bon : " + items.slice(0, 4).map((x) => x.nom).join(", ")
       + (items.length > 4 ? ", et " + (items.length - 4) + " autre"


### PR DESCRIPTION
Fixes #110

Le bouton ne vide que les fichiers (l'index corbeille), jamais les projets archives (`projects.delete`, un par un). Correctif minimal fidele a la regle du fichier (« un bouton qui ment... ») :
- des projets archives sont affiches -> le bouton dit **« Vider les fichiers — N, definitivement »** ;
- la corbeille ne contient que des fichiers -> il garde « Vider la corbeille » (sa portee EST le tout) ;
- la confirmation reprend le meme intitule. Comportement inchange par ailleurs.

L'option « etendre le vidage aux projets » a ete ecartee : `projects.delete` est une destruction Hermes distincte, avec sa propre confirmation (« votre dossier n'a pas bouge ») — les fusionner melangerait deux portes qui ne detruisent pas la meme chose.

Note : la couverture test_page du panneau corbeille (zero check aujourd'hui) meriterait une issue dediee si jugee critique — hors perimetre du correctif minimal.

## Verification (raf-bmax, Linux)
Les 4 suites vertes (test_page 647, test_serve 241+, personas, verif_ports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm