### PR TITLE
BRIEF et commentaires : les panneaux sans chiffre a rouiller

### DIFF
--- a/BRIEF.md
+++ b/BRIEF.md
@@ -15,8 +15,10 @@ aucune commande à taper ».
 **Développement terminé — jalon 4 committé (2026-08-09). Boucle de peaufinage
 automatique opérationnelle (2026-08-31).**
 - Le dépôt vit dans `~/projets/ulysse` (remote GitHub `LyssU_googlelike`).
-- Produit : `web/` (ulysse.html + css/js + serve.py), 10 panneaux branchés sur
-  les endpoints réels d'Hermes, terminal intégré (`/api/pty`), dictée,
+- Produit : `web/` (ulysse.html + css/js + serve.py), les panneaux branchés
+  sur les endpoints réels d'Hermes — leur liste de référence vit dans
+  `PANELS` (ulysse-app.js) : neuf ce jour, « Travaux » ayant fusionné dans
+  Discuter le 2026-08-21 —, terminal intégré (`/api/pty`), dictée,
   écriture mémoire avec versions, Projets complet.
 - 6 suites de tests — 4 en CI à chaque PR (`test_serve.py`, `test_page.js`,
   `test_personas.py`, `test_verif_ports.py`) et 2 locales (`test_page.py` :

--- a/web/ulysse-app.js
+++ b/web/ulysse-app.js
@@ -206,7 +206,7 @@ function memManquants(d){
 }
 
 /* Où la dette a un objet. Elle vit dans `.stage` : sans ce filtre elle
-   s'affiche sur les DIX panneaux et pousse le contenu de chacun. Elle est
+   s'affiche sur TOUS les panneaux et pousse le contenu de chacun. Elle est
    juste — un profil vide rend les réponses vagues — mais dans le Terminal ou
    les Repères, elle parle d'autre chose que ce qu'on est venu faire.
      · Discuter — c'est là qu'on lit la réponse vague ;
@@ -6093,7 +6093,7 @@ function onApproval(pl){
 }
 
 /* Comment un identifiant de panneau s'écrit à l'écran, pour la ligne « où mène
-   ceci ». La source est `PANELS` et elle seule : recopier les dix libellés
+   ceci ». La source est `PANELS` et elle seule : recopier les libellés
    ailleurs, c'est se donner une occasion de divergence dont la première victime
    serait justement celle que `drawBell()` vient de subir — « Reglages » d'un
    côté, « Réglages » de l'autre. */
@@ -6298,9 +6298,9 @@ let lastStatus = null;
    `decision` était poussé : le vocabulaire existait en entier, le produit en
    employait un quart.
 
-   Or l'état d'Hermès concerne les DIX panneaux. Il n'était lisible que dans
-   le bandeau du kebab de Discuter : juste pour Discuter, angle mort pour les
-   neuf autres. Depuis le Vestiaire, si le lien tombait, rien ne le disait.
+   Or l'état d'Hermès concerne TOUS les panneaux. Il n'était lisible que dans
+   le bandeau du kebab de Discuter : juste pour Discuter, angle mort pour
+   tous les autres. Depuis le Vestiaire, si le lien tombait, rien ne le disait.
 
    On ne crée pas un nouveau point qui veille : la cloche EST le lieu de ce
    qui ne va pas, elle est visible de partout, et `NKIND.panne.dur` vaut déjà


### PR DESCRIPTION
Fixes #114

- **BRIEF.md** : renvoie a `PANELS` comme liste de reference (« neuf ce jour, Travaux ayant fusionne dans Discuter le 2026-08-21 ») — la date et la raison plutot qu'un chiffre nu.
- **ulysse-app.js** : les trois commentaires « DIX panneaux » (l.209, 6096, 6301) passent a « tous les panneaux » / « les libelles » — plus aucun compte a maintenir dans la prose. (Le « neuf autres » de l.6303, devenu faux aussi, suit.)

Commentaires et doc seuls, aucun comportement touche. Suites vertes (personas re-verifie 3 runs apres un echec fugace non reproductible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm