### PR TITLE
CONTRAT : pTravaux sort de la liste vivante des panneaux

### DIFF
--- a/web/CONTRAT-INTERFACE.md
+++ b/web/CONTRAT-INTERFACE.md
@@ -83,8 +83,10 @@ n'avait pas de doublure, et il se rejoue en `.wait.inline` dans le fil.
 
 Le mot-marque n'a plus d'`id` : il porte `.u-marque` et rien ne le lit.
 
-**Les panneaux** — `pDiscuter` `pPlan` `pTravaux` `pLivrables` `pProjets`
+**Les panneaux** — `pDiscuter` `pPlan` `pLivrables` `pProjets`
 `pAutomatisations` `pVestiaire` `pReglages` `pTerminal` `pReperes`.
+(`pTravaux` a quitté la liste avec « Travaux », fusionné dans Discuter le
+2026-08-21 — la liste de référence est `PANELS`, ulysse-app.js.)
 `nav()` les compose (`"p" + destination`) : le nom du panneau et l'entrée du
 menu ne peuvent pas diverger. **`#pDiscuter` porte les cinq classes d'état.**
 


### PR DESCRIPTION
Fixes #120

`pTravaux` (0 occurrence dans ulysse.html et ulysse-app.js, verifie) sort de la liste des id vivants, avec la date et la raison en note, et le renvoi a `PANELS` comme reference.

Verification : test_page 647 et test_serve verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5iLULpBNYpfq21Rk7dtJm