### PR TITLE
Mobile : cibles tactiles >=44px (composeur, valider, fantome) — Fixes #122

### DIFF
--- a/web/apercu-accord.html
+++ b/web/apercu-accord.html
@@ -2025,6 +2025,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2038,7 +2040,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-discuter-v2.html
+++ b/web/apercu-discuter-v2.html
@@ -2051,6 +2051,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2064,7 +2066,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-discuter.html
+++ b/web/apercu-discuter.html
@@ -2036,6 +2036,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2049,7 +2051,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-ecriture-memoire.html
+++ b/web/apercu-ecriture-memoire.html
@@ -2041,6 +2041,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2054,7 +2056,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-fichiers.html
+++ b/web/apercu-fichiers.html
@@ -2043,6 +2043,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2056,7 +2058,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-lieu.html
+++ b/web/apercu-lieu.html
@@ -2035,6 +2035,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2048,7 +2050,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-listes.html
+++ b/web/apercu-listes.html
@@ -2026,6 +2026,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2039,7 +2041,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-notifications.html
+++ b/web/apercu-notifications.html
@@ -2031,6 +2031,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2044,7 +2046,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-plan.html
+++ b/web/apercu-plan.html
@@ -2033,6 +2033,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2046,7 +2048,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-premier-lancement.html
+++ b/web/apercu-premier-lancement.html
@@ -2027,6 +2027,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2040,7 +2042,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-projets.html
+++ b/web/apercu-projets.html
@@ -2037,6 +2037,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2050,7 +2052,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-rail.html
+++ b/web/apercu-rail.html
@@ -2033,6 +2033,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2046,7 +2048,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-reglages-terminal-reperes.html
+++ b/web/apercu-reglages-terminal-reperes.html
@@ -2021,6 +2021,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2034,7 +2036,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-terminal.html
+++ b/web/apercu-terminal.html
@@ -2030,6 +2030,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2043,7 +2045,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/apercu-vestiaire.html
+++ b/web/apercu-vestiaire.html
@@ -2022,6 +2022,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2035,7 +2037,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un

--- a/web/test_tactile.py
+++ b/web/test_tactile.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""test_tactile.py — cibles tactiles mobiles >=44px (issue #122).
+
+Script auto-executable (pas pytest) : `python3 test_tactile.py` -> exit 0/1.
+
+Parse web/ulysse.css et verifie, pour un viewport mobile de 360px (donc
+dans le perimetre de @media (max-width:720px)), que les regles EFFECTIVES
+(respectant la cascade CSS : ordre du fichier, regles de media queries
+applicables) donnent :
+
+  - .composer .icon-btn : width >=44px ET height >=44px (les deux
+    dimensions sont explicites dans le CSS) ;
+  - .validate           : height effective >=44px ;
+  - .ghost-btn          : height effective >=44px.
+
+Regle WCAG 2.5.5 / Material : cible tactile minimum 44x44px.
+"""
+import re
+import sys
+
+CSS_PATH = 'ulysse.css'
+VIEWPORT_W = 360          # px — telephone typique, <=720px
+MIN_TARGET = 44           # px — minimum WCAG 2.5.5
+
+
+def parse_rules(css):
+    """Retourne [(media, selector, decls)] dans l'ordre du fichier.
+
+    media : None (hors media query) ou la chaine de la condition, ex.
+    '(max-width:720px)'. Gere un niveau d'imbrication (blocs @media
+    simples, sans @media imbriques ni @supports). Les commentaires CSS
+    sont neutralises d'abord : certains contiennent des accolades qui
+    casseraient l'appariement des blocs.
+    """
+    css = re.sub(r'/\*.*?\*/', ' ', css, flags=re.S)
+    rules = []
+    i, n = 0, len(css)
+    while i < n:
+        # prochain '{' et le texte qui le precede
+        b = css.find('{', i)
+        if b == -1:
+            break
+        prelude = css[i:b].strip()
+        # trouver l'accolade fermante correspondante
+        depth, j = 1, b + 1
+        while j < n and depth:
+            if css[j] == '{':
+                depth += 1
+            elif css[j] == '}':
+                depth -= 1
+            j += 1
+        body = css[b + 1:j - 1]
+        if prelude.startswith('@media'):
+            cond = prelude[len('@media'):].strip()
+            for m in re.finditer(r'([^{}]+)\{([^{}]*)\}', body):
+                decls = m.group(2).strip()
+                for part in m.group(1).split(','):
+                    sel = part.strip()
+                    if sel:
+                        rules.append((cond, sel, decls))
+        elif prelude.startswith('@'):
+            # @keyframes, @import, ... : ignore
+            pass
+        else:
+            for part in prelude.split(','):
+                sel = part.strip()
+                if sel:
+                    rules.append((None, sel, body))
+        i = j
+    return rules
+
+
+def media_applies(cond):
+    """True si la condition media s'applique a un viewport de VIEWPORT_W px.
+
+    Ne gere que max-width (suffisant pour ce fichier) ; conditions
+    sans dimension pixel considerees non applicables par prudence.
+    """
+    if cond is None:
+        return True
+    for m in re.finditer(r'\(max-width\s*:\s*(\d+(?:\.\d+)?)px\)', cond):
+        if float(m.group(1)) >= VIEWPORT_W:
+            return True
+    return False
+
+
+def px(value):
+    """'44px' -> 44.0 ; None si pas une longueur px."""
+    m = re.fullmatch(r'\s*([+-]?\d+(?:\.\d+)?)px\s*', value or '')
+    return float(m.group(1)) if m else None
+
+
+def effective(rules, selector):
+    """Calcule width/height/min-height effectifs pour un viewport mobile.
+
+    Cascade simplifiee mais fidele ici : on balaie les regles dans
+    l'ordre du fichier ; une regle s'applique si le selecteur correspond
+    exactement (apres normalisation d'espaces) et que sa media query
+    couvre le viewport. La derniere declaration gagne.
+    """
+    want = re.sub(r'\s+', ' ', selector).strip()
+    eff = {'width': None, 'height': None, 'min-height': None}
+    matched = []
+    for cond, sel, decls in rules:
+        if re.sub(r'\s+', ' ', sel).strip() != want:
+            continue
+        if not media_applies(cond):
+            continue
+        matched.append((cond, decls))
+        for decl in decls.split(';'):
+            if ':' not in decl:
+                continue
+            prop, _, val = decl.partition(':')
+            prop = prop.strip().lower()
+            val = val.strip()
+            if prop in eff:
+                eff[prop] = val
+    return eff, matched
+
+
+def main():
+    try:
+        css = open(CSS_PATH, encoding='utf-8').read()
+    except OSError as e:
+        print(f'ERREUR: lecture de {CSS_PATH}: {e}')
+        return 1
+    rules = parse_rules(css)
+
+    failures = []
+
+    # --- .composer .icon-btn : width ET height explicites >=44px ---------
+    sel = '.composer .icon-btn'
+    eff, matched = effective(rules, sel)
+    w, h = px(eff['width']), px(eff['height'])
+    if not matched:
+        failures.append(f'{sel}: aucune regle mobile applicable')
+    else:
+        if w is None or w < MIN_TARGET:
+            failures.append(f'{sel}: width effective {eff["width"]!r} < {MIN_TARGET}px')
+        if h is None or h < MIN_TARGET:
+            failures.append(f'{sel}: height effective {eff["height"]!r} < {MIN_TARGET}px')
+
+    # --- .validate / .ghost-btn : height effective >=44px ----------------
+    for sel in ('.validate', '.ghost-btn'):
+        eff, matched = effective(rules, sel)
+        h = px(eff['height'])
+        minh = px(eff['min-height'])
+        ok = (h is not None and h >= MIN_TARGET) or \
+             (h is None and minh is not None and minh >= MIN_TARGET)
+        if not ok:
+            failures.append(
+                f'{sel}: height effective {eff["height"]!r} '
+                f'(min-height {eff["min-height"]!r}) < {MIN_TARGET}px sur mobile')
+
+    # --- rapport ----------------------------------------------------------
+    print(f'test_cibles_tactiles_mobile_44px — viewport {VIEWPORT_W}px, '
+          f'minimum {MIN_TARGET}x{MIN_TARGET}px')
+    for sel in ('.composer .icon-btn', '.validate', '.ghost-btn'):
+        eff, matched = effective(rules, sel)
+        print(f'  {sel}: width={eff["width"]!r} height={eff["height"]!r} '
+              f'min-height={eff["min-height"]!r} '
+              f'({len(matched)} regle(s) applicable(s))')
+    if failures:
+        print('ECHEC:')
+        for f in failures:
+            print(f'  - {f}')
+        return 1
+    print('OK: toutes les cibles tactiles mobiles >=44px.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/web/ulysse.css
+++ b/web/ulysse.css
@@ -2001,6 +2001,8 @@ svg.graph *{cursor:inherit}
   .rail-btn{min-height:46px;height:auto}
   .rail-top .icon-btn{width:44px;height:44px}
   .bellbtn{min-height:46px}
+  /* Les boutons d'action montent aussi a la taille tactile (issue #122). */
+  .validate,.ghost-btn{height:44px}
   /* Les panneaux occupent toute la largeur, sans marge latérale parasite. */
   .panel{width:100vw;inset:0}
   .stage{padding:0}
@@ -2014,7 +2016,7 @@ svg.graph *{cursor:inherit}
      (jamais 100vw, qui suit le viewport et pas le conteneur). */
   .composer,.wait{width:min(720px,calc(100% - 24px))}
   .composer input,.composer textarea{min-width:0;flex:1 1 0;width:0}
-  .composer .icon-btn{width:40px;height:40px}
+  .composer .icon-btn{width:44px;height:44px}
   .foot{padding:12px 12px 16px}
   /* ⚠ LE KEBAB DOIT RESTER DANS L'ÉCRAN À 100 % DE ZOOM. La topbar est un
      flex : titre + pastille d'incognito + lieu (max 280px) + kebab. Sur un


### PR DESCRIPTION
Fixes #122

## REPRO
Sur Ulysse avec une fenêtre ≤720px (mobile ou devtools), constaté dans `web/ulysse.css` :
- `.composer .icon-btn{width:40px;height:40px}` (bloc `@media (max-width:720px)`) : les boutons du composeur font 40×40px ;
- `.validate{…height:40px…}` sans override mobile : le bouton « Valider » des fiches fait 40px de haut ;
- `.ghost-btn{height:40px…}` sans override mobile : les actions fantômes font 40px de haut.

Or le commentaire du bloc responsive promet « les zones tactiles montent à ≥44px » (WCAG 2.5.5).

## TEST
- `web/test_tactile.py` — `test_cibles_tactiles_mobile_44px`, script auto-exécutable (pas pytest).
- Parse `ulysse.css`, calcule les règles EFFECTIVES pour un viewport 360px (cascade top-level + bloc 720px, commentaires neutralisés).
- Rouge prouvé avant fix (exit 1, 4 échecs : composeur 40×40, validate 40, ghost-btn 40) — rejoué par le clapet contre le CSS de master.
- Vert après fix (exit 0).

## FIX
- `ulysse.css`, bloc `@media (max-width:720px)` uniquement : `.composer .icon-btn` 40→44×44 ; override ajoutée `.validate,.ghost-btn{height:44px}`. Desktop intact, `.icon-btn.sm` et `.rail-top .icon-btn` hors périmètre intacts.
- 2e commit : recopie de la feuille dans les 15 `apercu-*.html` (exigé par `test_page.js` : les aperçus portent la feuille COURANTE). Contenu produit par `resync_apercus.py`, octet-pour-octet identique à la propagation déjà validée par Raf.
- Registre `ECARTS-MAQUETTE.md` : non concerné — la maquette ne porte ni `.composer .icon-btn` ni aucune règle mobile pour ces boutons ; le 40px est une régression du repo, pas une décision de maquette à inscrire.

## Suite complète
- `test_tactile.py` → exit 0
- `test_serve.py` → 244/244
- `test_personas.py` → 127/127
- `test_page.js` → vérifié par le clapet sur la branche (CI repo le rejoue)

## Note de boucle
Issue traitée par l'agent QA (cron `qa-agent-ulysse-poll`, skill qa-loop). Première PR (#123) contaminée par un commit live atterri sur le checkout partagé pendant le run ; branchée propre ici par cherry-pick du seul commit QA + resync des aperçus. #123 sera fermée sans merge.